### PR TITLE
Modifications for Grocy 4.x

### DIFF
--- a/src/GrocyApi.php
+++ b/src/GrocyApi.php
@@ -27,6 +27,11 @@ class GrocyApi {
     {
       return json_decode($this->request(self::GET_REQUEST,"objects/products/".$productid, '',true));
     }
+
+    public function getProductStore($productid)
+    {
+      return json_decode($this->request(self::GET_REQUEST,"stock/products/".$productid, '',true));
+    }
    
     public function getShoppingLocationEntity($shoppinglocationid)
     {

--- a/src/index.php
+++ b/src/index.php
@@ -39,10 +39,16 @@ foreach($missing_products as $p){
         echo "Skipping Bring for $p->name because is partly in stock (custom setting) \n";
     }else{
         $product_details = $grocy->getProductEntity($p->id);
+		$product_store = $grocy->getProductStore($p->id);
         $bringlist = $grocy->getBringUUID($product_details->shopping_location_id, getenv('BRINGUUIDFIELD'), $bringuuid);
-        $purchase_unit_name = $grocy->quantities[$product_details->qu_id_purchase]["name"];
-        if(empty($bring->saveItem($bringlist, clean($p->name), (abs(intval($p->amount_missing))).' '.$purchase_unit_name))){
-            echo "Added ".clean($p->name)." to bring \n";
+	    $purchase_quantity = (ceil($p->amount_missing / $product_store->qu_conversion_factor_purchase_to_stock));
+		if ($purchase_quantity > 1){
+			$purchase_unit_name = $grocy->quantities[$product_details->qu_id_purchase]["name_plural"];
+		}else{
+			$purchase_unit_name = $grocy->quantities[$product_details->qu_id_purchase]["name"];
+		};
+        if(empty($bring->saveItem($bringlist, clean($p->name), $purchase_quantity.' '.$purchase_unit_name))){
+            echo "Added $purchase_quantity $purchase_unit_name ".clean($p->name)." to bring \n";
         }else{
             echo "Error adding $p->name to bring \n";
         };


### PR DESCRIPTION
In Grocy 4.0.0 the pruduct property "qu_factor_purchase_to_stock" was removed which led to a division by zero error.

Replacement for correct calculations is "qu_conversion_factor_purchase_to_stock" which is a product field in the store API.

This commit changes the calculation to use the new field, in addition it uses the plural quantity name if the amount to purchase is >1